### PR TITLE
timeout to search for a signal from 300 seconds down to 15

### DIFF
--- a/src/product.hpp
+++ b/src/product.hpp
@@ -161,7 +161,7 @@
 /**
  * how long to stay in data upload without a cell signal/connection/succesful upload
  */
-#define SF_CELL_SIGNAL_TIMEOUT_MS 300000
+#define SF_CELL_SIGNAL_TIMEOUT_MS 15000
 
 
 


### PR DESCRIPTION
this is helpful for resting on the 3g modules (that will never connect to a network ever)