### PR TITLE
CLI exits debug mode on usb disconnect

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -362,11 +362,7 @@ static void CLI_doDebugMode(void)
     {
         CLI_displayDebugMenu(CLI_debugMenu);
         SF_OSAL_printf("*>");
-        getline(inputBuffer, 80);
-        
-        if(!pSystemDesc->flags->hasCharger) {
-            return;
-        }
+        if (getline(inputBuffer, 80) == -1) break;
 
         if(strlen(inputBuffer) == 0)
         {

--- a/src/conio.cpp
+++ b/src/conio.cpp
@@ -123,7 +123,7 @@ extern "C"
                 }
             }
             if(!pSystemDesc->flags->hasCharger) {
-                break;
+                return -1;
             }
             
         }


### PR DESCRIPTION
Has getline exit when it detects usb is disconnected from conio

Resolves issue #50 